### PR TITLE
Get all usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ TEST_CHARGIFY_SUBDOMAIN=<subdomain> \
 TEST_CHARGIFY_PRODUCT_FAMILY_ID=<product-family-id> \
 TEST_CHARGIFY_COMPONENT_1_ID=<component-id> \
 TEST_CHARGIFY_COMPONENT_1_HANDLE=<component-handle> \
+TEST_CHARGIFY_USAGE_1_COMPONENT_ID=<component-id> \
+TEST_CHARGIFY_USAGE_1_SUBSCRIPTION_ID=<subscription-id> \
 npm test
 ```
 

--- a/src/chargify-client.ts
+++ b/src/chargify-client.ts
@@ -2,6 +2,7 @@ import {getComponent, IGetComponentRequest, IGetComponentResponse} from './compo
 import {getComponents, IGetComponentsRequest, IGetComponentsResponse} from './components/get-components';
 import {getCustomers, IGetCustomersResponse} from './customers/get-customers';
 import {getSubscriptions, IGetSubscriptionsResponse} from './subscriptions/get-subscriptions';
+import {getUsages, IGetUsagesRequest, IGetUsagesResponse} from './usages/get-usages';
 
 export class ChargifyClient {
   private _options: IChargifyClientOptions;
@@ -24,6 +25,10 @@ export class ChargifyClient {
 
   public async getSubscriptions(): Promise<IGetSubscriptionsResponse> {
     return getSubscriptions(this._options.subdomain, this._options.apiKey)();
+  }
+
+  public async getUsages(input: IGetUsagesRequest): Promise<IGetUsagesResponse> {
+    return getUsages(this._options.subdomain, this._options.apiKey)(input);
   }
 }
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,6 +3,7 @@ import {getComponentSpec} from './components/get-component.spec';
 import {getComponentsSpec} from './components/get-components.spec';
 import {getCustomersSpec} from './customers/get-customers.spec';
 import {getSubscriptionsSpec} from './subscriptions/get-subscriptions.spec';
+import {getUsagesSpec} from './usages/get-usages.spec';
 
 const productFamilyId = process.env.TEST_CHARGIFY_PRODUCT_FAMILY_ID && parseInt(process.env.TEST_CHARGIFY_PRODUCT_FAMILY_ID) || 100000;
 const component1Id = process.env.TEST_CHARGIFY_COMPONENT_1_ID && parseInt(process.env.TEST_CHARGIFY_COMPONENT_1_ID) || 200000;
@@ -16,6 +17,10 @@ const options: TestOptions = {
     productFamilyId,
     component1Id,
     component1Handle: process.env.TEST_CHARGIFY_COMPONENT_1_HANDLE || 'test_component_handle',
+  },
+  usagesTest1: {
+    componentId: process.env.TEST_CHARGIFY_USAGE_1_COMPONENT_ID && parseInt(process.env.TEST_CHARGIFY_USAGE_1_COMPONENT_ID) || 100000,
+    subscriptionId: process.env.TEST_CHARGIFY_USAGE_1_SUBSCRIPTION_ID && parseInt(process.env.TEST_CHARGIFY_USAGE_1_SUBSCRIPTION_ID) || 200000,
   }
 }
 
@@ -24,3 +29,4 @@ getComponentSpec(options);
 getComponentsSpec(options);
 getCustomersSpec(options);
 getSubscriptionsSpec(options);
+getUsagesSpec(options);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,7 @@ import {getComponentsSpec} from './components/get-components.spec';
 import {getCustomersSpec} from './customers/get-customers.spec';
 import {getSubscriptionsSpec} from './subscriptions/get-subscriptions.spec';
 import {getUsagesSpec} from './usages/get-usages.spec';
+import {requestSpec} from './request.spec';
 
 const productFamilyId = process.env.TEST_CHARGIFY_PRODUCT_FAMILY_ID && parseInt(process.env.TEST_CHARGIFY_PRODUCT_FAMILY_ID) || 100000;
 const component1Id = process.env.TEST_CHARGIFY_COMPONENT_1_ID && parseInt(process.env.TEST_CHARGIFY_COMPONENT_1_ID) || 200000;
@@ -30,3 +31,4 @@ getComponentsSpec(options);
 getCustomersSpec(options);
 getSubscriptionsSpec(options);
 getUsagesSpec(options);
+requestSpec(options);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,5 @@
 export type ChargifyId = number;
-export type ChargifyDate = string | null;
+export type ChargifyDate = string | null; // example: "2019-01-30T11:56:05-08:00"
 
 export interface IChargifyComponent {
   id: ChargifyId;
@@ -155,4 +155,16 @@ export interface IChargifyProduct {
   }[],
   taxable: boolean;
   version_number: number;
+}
+
+// Metered component usage
+export interface IChargifyUsage {
+  id: ChargifyId;
+  memo: string;
+  created_at: ChargifyDate;
+  price_point_id: ChargifyId;
+  quantity: number;
+  component_id: ChargifyId;
+  component_handle: string;
+  subscription_id: ChargifyId;
 }

--- a/src/options.spec.ts
+++ b/src/options.spec.ts
@@ -9,4 +9,8 @@ export interface TestOptions {
     component1Id: ChargifyId;
     component1Handle: string;
   }
+  usagesTest1: {
+    componentId: ChargifyId;
+    subscriptionId: ChargifyId;
+  }
 }

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -1,0 +1,103 @@
+import test from 'ava';
+import * as nock from 'nock';
+import {TestOptions} from './options.spec';
+import {getAllPages} from './request';
+
+interface MockResource {
+  key1: string;
+  key2: number;
+}
+
+export function requestSpec(options: TestOptions) {
+  test('getAllPages should return single page of Chargify objects', async (t) => {
+    const path = '/test_path';
+
+    const page1 = [
+      {
+        key1: 'value1',
+        key2: 1,
+      },
+      {
+        key1: 'value2',
+        key2: 2,
+      }
+    ];
+
+    const mockedPage1 = nock(`https://${options.chargify.subdomain}.chargify.com`)
+    .get(path)
+    .query({page: 1, per_page: 20})
+    .reply(200, page1)
+
+    const response = await getAllPages<MockResource>({
+      apiKey: options.chargify.apiKey,
+      subdomain: options.chargify.subdomain,
+      path,
+    });
+    t.true(response.ok);
+    t.deepEqual(await response.json(), page1);
+    mockedPage1.done();
+  })
+
+  test('getAllPages should return multiple pages of Chargify objects', async (t) => {
+    const path = '/test_path';
+    const testPerPage = 2;
+
+    const page1 = [
+      {
+        key1: 'value1',
+        key2: 1,
+      },
+      {
+        key1: 'value2',
+        key2: 2,
+      }
+    ];
+
+    const page2 = [
+      {
+        key1: 'value3',
+        key2: 3,
+      }
+    ];
+
+    const mockedPage1 = nock(`https://${options.chargify.subdomain}.chargify.com`)
+    .get(path)
+    .query({page: 1, per_page: 2})
+    .reply(200, page1)
+
+    const mockedPage2 = nock(`https://${options.chargify.subdomain}.chargify.com`)
+    .get(path)
+    .query({page: 2, per_page: 2})
+    .reply(200, page2)
+
+    const response = await getAllPages<MockResource>({
+      apiKey: options.chargify.apiKey,
+      subdomain: options.chargify.subdomain,
+      path,
+      perPage: testPerPage,
+    });
+    t.true(response.ok);
+    t.deepEqual(await response.json(), [...page1, ...page2]);
+    mockedPage1.done();
+    mockedPage2.done();
+  })
+
+  test('getAllPages should return first error from Chargify', async (t) => {
+    const path = '/test_path';
+
+    const mockedError = nock(`https://${options.chargify.subdomain}.chargify.com`)
+    .get(path)
+    .query(true)
+    .reply(422)
+
+    const response = await getAllPages<MockResource>({
+      apiKey: options.chargify.apiKey,
+      subdomain: options.chargify.subdomain,
+      path,
+    });
+
+    t.false(response.ok);
+    t.is(response.status, 422);
+    mockedError.done();
+  })
+}

--- a/src/usages/get-usages.mock.spec.ts
+++ b/src/usages/get-usages.mock.spec.ts
@@ -1,0 +1,33 @@
+import * as nock from 'nock';
+import { IChargifyUsage } from '../interfaces';
+import { TestOptions } from '../options.spec';
+
+export interface IUsageMock {
+  mock: nock.Scope;
+  usages: IChargifyUsage[];
+}
+
+export function mockUsagesTest1(options: TestOptions): IUsageMock {
+  const usages: IChargifyUsage[] = [
+    {
+      id: 101010,
+      memo: 'testMemo',
+      created_at: '2019-01-30T11:56:05-08:00',
+      price_point_id: 202020,
+      quantity: 3,
+      component_id: options.usagesTest1.componentId,
+      component_handle: 'component_handle',
+      subscription_id: options.usagesTest1.subscriptionId,
+    }
+  ];
+
+  // base64-encoded Chargify credentials
+  const basicAuth = Buffer.from(`${options.chargify.apiKey}:x`).toString('base64');
+
+  const mock = nock(`https://${options.chargify.subdomain}.chargify.com`)
+  .matchHeader('Authorization', `Basic ${basicAuth}`)
+  .get(`/subscriptions/${options.usagesTest1.subscriptionId}/components/${options.usagesTest1.componentId}/usages.json`)
+  .reply(200, usages.map(usage => ({usage}))) // wrap each usage object
+
+  return {mock, usages};
+}

--- a/src/usages/get-usages.mock.spec.ts
+++ b/src/usages/get-usages.mock.spec.ts
@@ -27,6 +27,7 @@ export function mockUsagesTest1(options: TestOptions): IUsageMock {
   const mock = nock(`https://${options.chargify.subdomain}.chargify.com`)
   .matchHeader('Authorization', `Basic ${basicAuth}`)
   .get(`/subscriptions/${options.usagesTest1.subscriptionId}/components/${options.usagesTest1.componentId}/usages.json`)
+  .query({page: 1, per_page: 20})
   .reply(200, usages.map(usage => ({usage}))) // wrap each usage object
 
   return {mock, usages};

--- a/src/usages/get-usages.spec.ts
+++ b/src/usages/get-usages.spec.ts
@@ -1,0 +1,40 @@
+import test from 'ava';
+import {getUsages} from './get-usages';
+import {TestOptions} from '../options.spec';
+import {mockUsagesTest1} from './get-usages.mock.spec';
+
+export function getUsagesSpec(options: TestOptions) {
+  options.chargify.skipMocks ? testWithoutMocks(options) : testWithMocks(options);
+}
+
+function testWithMocks(options: TestOptions) {
+  test('getUsages should return list of usages', async (t) => {
+    const {usages, mock} = mockUsagesTest1(options);
+    const response = await getUsages(options.chargify.subdomain, options.chargify.apiKey)({
+      componentId: options.usagesTest1.componentId,
+      subscriptionId: options.usagesTest1.subscriptionId,
+    });
+    t.deepEqual(response.usages, usages);
+    mock.done();
+  })
+}
+
+function testWithoutMocks(options: TestOptions) {
+  test('getUsages should return list of usages', async (t) => {
+    const response = await getUsages(options.chargify.subdomain, options.chargify.apiKey)({
+      componentId: options.usagesTest1.componentId,
+      subscriptionId: options.usagesTest1.subscriptionId
+    });
+    t.is(response.error, null);
+    t.true(Array.isArray(response.usages));
+  })
+
+  test('getUsages should return error with HTTP status code 401 when no API key provided', async (t) => {
+    const response = await getUsages(options.chargify.subdomain, undefined)({
+      componentId: options.usagesTest1.componentId,
+      subscriptionId: options.usagesTest1.subscriptionId
+    });
+    t.is(response.error.statusCode, 401);
+    t.is(response.usages, null);
+  })
+}

--- a/src/usages/get-usages.ts
+++ b/src/usages/get-usages.ts
@@ -1,0 +1,38 @@
+import {IChargifyUsage, ChargifyId} from '../interfaces';
+import {ChargifyApiError} from '../error';
+import {get} from '../request';
+
+export interface IGetUsagesRequest {
+  componentId: ChargifyId;
+  subscriptionId: ChargifyId;
+}
+
+export interface IGetUsagesResponse {
+  error: ChargifyApiError | null;
+  usages: IChargifyUsage[] | null;
+}
+
+export function getUsages(subdomain: string, apiKey: string) {
+  /**
+   * Get all usages for the given subscription and component.
+   */
+  return async (input: IGetUsagesRequest): Promise<IGetUsagesResponse> => {
+    const response = await get<{usage: IChargifyUsage}[]>({
+      path: `/subscriptions/${input.subscriptionId}/components/${input.componentId}/usages.json`,
+      subdomain,
+      apiKey,
+    });
+    if (!response.ok) {
+      return {
+        error: new ChargifyApiError(response.status, 'Failed to get usages'),
+        usages: null,
+      };
+    }
+    const rawUsages = await response.json();
+    const usages = rawUsages.map((usage) => usage.usage);
+    return {
+      error: null,
+      usages,
+    };
+  }
+}

--- a/src/usages/get-usages.ts
+++ b/src/usages/get-usages.ts
@@ -1,6 +1,6 @@
 import {IChargifyUsage, ChargifyId} from '../interfaces';
 import {ChargifyApiError} from '../error';
-import {get} from '../request';
+import {getAllPages} from '../request';
 
 export interface IGetUsagesRequest {
   componentId: ChargifyId;
@@ -17,7 +17,7 @@ export function getUsages(subdomain: string, apiKey: string) {
    * Get all usages for the given subscription and component.
    */
   return async (input: IGetUsagesRequest): Promise<IGetUsagesResponse> => {
-    const response = await get<{usage: IChargifyUsage}[]>({
+    const response = await getAllPages<{usage: IChargifyUsage}>({
       path: `/subscriptions/${input.subscriptionId}/components/${input.componentId}/usages.json`,
       subdomain,
       apiKey,


### PR DESCRIPTION
[Chargify usage listing is paginated](https://reference.chargify.com/v1/components-metered-usage/list-usage-by-subscription), so this PR also creates `getAllPages` for supporting paginated endpoints.